### PR TITLE
[Feat/#15] SectionSeperator 구현

### DIFF
--- a/react_native/src/components/SectionSeperator.tsx
+++ b/react_native/src/components/SectionSeperator.tsx
@@ -1,0 +1,40 @@
+import { semanticColor } from '@/styles/semantic-color';
+import { View, StyleSheet } from 'react-native';
+
+type SectionSeparatorType = 'line-with-padding' | 'line' | 'rectangle';
+
+interface SectionSeparatorProps {
+  type?: SectionSeparatorType;
+}
+
+const SectionSeparator = ({ type = 'line' }: SectionSeparatorProps) => {
+  switch (type) {
+    case 'line-with-padding':
+      return <View style={[styles.lineWithPadding]} />;
+    case 'rectangle':
+      return <View style={[styles.rectangle]} />;
+    case 'line':
+    default:
+      return <View style={[styles.line]} />;
+  }
+};
+
+const styles = StyleSheet.create({
+  lineWithPadding: {
+    height: 1,
+    marginHorizontal: 16,
+    marginVertical: 8,
+    backgroundColor: semanticColor.border.medium,
+  },
+  line: {
+    height: 1,
+    marginVertical: 8,
+    backgroundColor: semanticColor.border.medium,
+  },
+  rectangle: {
+    height: 16,
+    backgroundColor: semanticColor.surface.gray,
+  },
+});
+
+export default SectionSeparator;


### PR DESCRIPTION
📑 이슈 번호
close #15 

✨️ 작업 내용
SectionSeperator 구현: props의 type으로 구분

💭 코멘트

📸 구현 결과

<img width="351" height="140" alt="image" src="https://github.com/user-attachments/assets/78653a13-603c-4ebc-8868-504d45d534a1" />

line-with-padding, line, rectangle 순서